### PR TITLE
Feature/search mods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.bmuschko.docker-remote-api'
 apply plugin: 'nebula.docker'
 apply plugin: 'jacoco'
 
-version = '1.8.1'
+version = '1.8.2'
 group 'com.github.ssullivan'
 mainClassName = 'com.github.ssullivan.ApiApplication'
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 ---
 Changelog
 --
+v1.8.2
+* FEATURE: Allow the specification of multiple search sets to search by. This is achieved by doing something like serviceCodes=a,b,c&serviceCodes=d,e,f&matchAny=x,y,z
+
 v1.8.1
 * FEATURE: Added the ability to specify service as comma separated lists (this only affects the v2)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ---
 Changelog
+--
 v1.8.1
 * FEATURE: Added the ability to specify service as comma separated lists (this only affects the v2)
 

--- a/src/main/java/com/github/ssullivan/db/IFacilityDao.java
+++ b/src/main/java/com/github/ssullivan/db/IFacilityDao.java
@@ -30,6 +30,8 @@ public interface IFacilityDao {
   CompletionStage<SearchResults<Facility>> find(final SearchRequest searchRequest,
       final Page page) throws Exception;
 
+  CompletionStage<SearchResults<Facility>> findV3(final SearchRequest searchRequest,
+      final Page page) throws Exception;
   /**
    * Finds the all of the facilities that any of the specified service codes.
    *

--- a/src/main/java/com/github/ssullivan/model/SearchRequest.java
+++ b/src/main/java/com/github/ssullivan/model/SearchRequest.java
@@ -1,7 +1,12 @@
 package com.github.ssullivan.model;
 
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.List;
+
 public class SearchRequest {
   private GeoRadiusCondition geoRadiusCondition;
+  private List<ServicesCondition> conditions;
   private ServicesCondition firstCondition;
   private ServicesCondition secondCondition;
   private ServicesCondition mustNotCondition;
@@ -14,27 +19,41 @@ public class SearchRequest {
     this.geoRadiusCondition = geoRadiusCondition;
   }
 
+  @Deprecated
   public ServicesCondition getFirstCondition() {
     return firstCondition;
   }
 
+  @Deprecated
   public void setFirstCondition(ServicesCondition firstCondition) {
     this.firstCondition = firstCondition;
   }
 
+  @Deprecated
   public ServicesCondition getSecondCondition() {
     return secondCondition;
   }
 
+  @Deprecated
   public void setSecondCondition(ServicesCondition secondCondition) {
     this.secondCondition = secondCondition;
   }
 
+  @Deprecated
   public ServicesCondition getMustNotCondition() {
     return mustNotCondition;
   }
 
+  @Deprecated
   public void setMustNotCondition(ServicesCondition mustNotCondition) {
     this.mustNotCondition = mustNotCondition;
+  }
+
+  public void setServiceConditions(final Collection<ServicesCondition> conditions) {
+    this.conditions = ImmutableList.copyOf(conditions);
+  }
+
+  public List<ServicesCondition> getConditions() {
+    return conditions;
   }
 }

--- a/src/main/java/com/github/ssullivan/model/ServicesCondition.java
+++ b/src/main/java/com/github/ssullivan/model/ServicesCondition.java
@@ -1,32 +1,60 @@
 package com.github.ssullivan.model;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Sets;
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 public class ServicesCondition {
-  private ImmutableSet<String> services;
+
+  private ImmutableSet<String> serviceCodes;
+  private ImmutableSet<String> mustNotServiceCodes;
   private MatchOperator matchOperator;
 
-  public ServicesCondition(final Collection<String> services, final MatchOperator matchOperator) {
-    this.services = ImmutableSet.copyOf(services);
+  /**
+   * If any of the service codes in the set start with a ! those will be negated from the search results.
+   *
+   * These are valid
+   * !a,b,c,!d
+   *
+   * or
+   * a,b,c,d,e
+   *
+   * @param serviceCodes a list of service codes
+   */
+  public ServicesCondition(final Collection<String> serviceCodes, final MatchOperator matchOperator) {
+    final ImmutableSet.Builder<String> serviceCodesBuilder = new Builder<>();
+    final ImmutableSet.Builder<String> mustNotServiceCodes = new Builder<>();
+
+    for (final String serviceCode : serviceCodes) {
+      if (serviceCode.startsWith("!")) {
+        mustNotServiceCodes.add(serviceCode.substring(1).trim());
+      }
+      else {
+        serviceCodesBuilder.add(serviceCode.trim());
+      }
+    }
+    this.serviceCodes = serviceCodesBuilder.build();
+    this.mustNotServiceCodes = mustNotServiceCodes.build();
     this.matchOperator = matchOperator;
   }
 
-  public ImmutableSet<String> getServices() {
-    return services;
+  public Set<String> getServices() {
+    return ImmutableSet.copyOf(this.serviceCodes);
+  }
+
+  public ImmutableSet<String> getServiceCodes() {
+    return serviceCodes;
+  }
+
+  public ImmutableSet<String> getMustNotServiceCodes() {
+    return mustNotServiceCodes;
   }
 
   public MatchOperator getMatchOperator() {
     return matchOperator;
-  }
-
-  public ServicesCondition union(final ServicesCondition other) {
-    if (other == null) {
-      return new ServicesCondition(getServices(), this.matchOperator);
-    }
-
-    return new ServicesCondition(Sets.union(other.getServices(), this.services),
-        this.matchOperator);
   }
 }

--- a/src/main/java/com/github/ssullivan/model/ServicesConditionFactory.java
+++ b/src/main/java/com/github/ssullivan/model/ServicesConditionFactory.java
@@ -1,0 +1,33 @@
+package com.github.ssullivan.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import java.util.List;
+
+public class ServicesConditionFactory {
+
+  public ImmutableList<ServicesCondition> fromRequestParams(final List<String> serviceCodes, final List<String> matchAny) {
+    final ImmutableList.Builder<ServicesCondition> builder = new ImmutableList.Builder<>();
+    builder.addAll(fromList(serviceCodes, MatchOperator.MUST));
+    builder.addAll(fromList(matchAny, MatchOperator.SHOULD));
+    return builder.build();
+  }
+
+  private List<ServicesCondition> fromList(final List<String> serviceCodes, final MatchOperator matchOperator) {
+    if (null == serviceCodes) {
+      return ImmutableList.of();
+    }
+    final ImmutableList.Builder<ServicesCondition> builder = new Builder<>();
+    serviceCodes.stream()
+        .map(s -> {
+              if (s.contains(",")) {
+                return new ServicesCondition(ImmutableList.copyOf(s.split(",")), matchOperator);
+              } else {
+                return new ServicesCondition(ImmutableList.of(s), matchOperator);
+              }
+            }
+        )
+        .forEach(builder::add);
+    return builder.build();
+  }
+}

--- a/src/main/java/com/github/ssullivan/resources/FacilitySearchResource.java
+++ b/src/main/java/com/github/ssullivan/resources/FacilitySearchResource.java
@@ -11,6 +11,7 @@ import com.github.ssullivan.model.Page;
 import com.github.ssullivan.model.SearchRequest;
 import com.github.ssullivan.model.SearchResults;
 import com.github.ssullivan.model.ServicesCondition;
+import com.github.ssullivan.model.ServicesConditionFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.Api;
@@ -58,7 +59,7 @@ public class FacilitySearchResource {
     this.postalcodeService = postalcodeService;
   }
 
-  @ApiOperation(value = "Find treatment facilities by their services and location",
+  @ApiOperation(value = "Find treatment facilities by their services and location. When multiple serviceCode, and matchAny sets are specified those results will be unified together",
       response = SearchResults.class)
   @ApiResponses(value = {
       @ApiResponse(code = 200,
@@ -75,9 +76,10 @@ public class FacilitySearchResource {
       @QueryParam("postalCode") final String postalCode,
 
 
-      @ApiParam(value = "The SAMSHA service code. service code prefixed with a single bang '!' will be negated", allowMultiple = true)
+      @ApiParam(value = "A comma separated list of service codes. service code prefixed with a single bang '!' will be negated", allowMultiple = true)
       @QueryParam("serviceCode") final List<String> serviceCodes,
 
+      @ApiParam(value = "A comma separated list of service codes.", allowMultiple = true)
       @QueryParam("matchAny") final List<String> matchAnyServiceCodes,
 
       @ApiParam(value = "the latitude coordinate according to WGS84", allowableValues = "range[-90,90]")
@@ -120,27 +122,9 @@ public class FacilitySearchResource {
         return;
       }
 
-      final List<String> flattenServicCodes = RequestUtils.flatten(serviceCodes);
-      final List<String> flattenMatchAny = RequestUtils.flatten(matchAnyServiceCodes);
-
-      final List<String> mustNotServiceCodes =
-          flattenServicCodes
-              .stream()
-              .filter(it -> it.startsWith("!"))
-              .map(it -> it.substring(1))
-              .collect(Collectors.toList());
-
-      final List<String> mustServiceCodes =
-          flattenServicCodes
-              .stream()
-              .filter(it -> !it.startsWith("!"))
-              .collect(Collectors.toList());
-
       final SearchRequest searchRequest = new SearchRequest();
-      searchRequest.setMustNotCondition(new ServicesCondition(mustNotServiceCodes, MatchOperator.MUST_NOT));
-      searchRequest.setFirstCondition(new ServicesCondition(mustServiceCodes, MatchOperator.MUST));
-      searchRequest.setSecondCondition(new ServicesCondition(flattenMatchAny, MatchOperator.SHOULD));
-
+      final ServicesConditionFactory factory = new ServicesConditionFactory();
+      searchRequest.setServiceConditions(factory.fromRequestParams(serviceCodes, matchAnyServiceCodes));
 
       if (lat != null && lon != null && !GeoPoint.isValidLatLong(lat, lon) && postalCode == null) {
         asyncResponse.resume(
@@ -161,7 +145,7 @@ public class FacilitySearchResource {
           searchRequest.setGeoRadiusCondition(new GeoRadiusCondition(geoPoints.get(0), distance, distanceUnit));
         }
       }
-      this.facilityDao.find(searchRequest, Page.page(offset, size))
+      this.facilityDao.findV3(searchRequest, Page.page(offset, size))
           .whenComplete((result, error) -> {
               if (error != null) {
                 LOGGER.error("Failed to find facilities with service codes`", error);

--- a/src/test/java/com/github/ssullivan/model/ServicesConditionFactoryTest.java
+++ b/src/test/java/com/github/ssullivan/model/ServicesConditionFactoryTest.java
@@ -1,0 +1,44 @@
+package com.github.ssullivan.model;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.hamcrest.junit.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+class ServicesConditionFactoryTest {
+
+  @Test
+  public void testMultipleServiceCodeSets() {
+    final List<String> input = ImmutableList.of("a,b,d,e", "x", "y", "z");
+    ServicesConditionFactory factory = new ServicesConditionFactory();
+    ImmutableList<ServicesCondition> conditions =
+        factory.fromRequestParams(input, ImmutableList.of());
+
+    MatcherAssert.assertThat(conditions, Matchers.hasSize(4));
+    MatcherAssert.assertThat(conditions.get(0).getServices(),
+        Matchers.containsInAnyOrder("a", "b", "d", "e"));
+  }
+
+  @Test
+  public void testMultipleServiceCodeSetsWithNegation() {
+    final List<String> input = ImmutableList.of("a,!b,!d,e", "x", "y", "z");
+    ServicesConditionFactory factory = new ServicesConditionFactory();
+    ImmutableList<ServicesCondition> conditions =
+        factory.fromRequestParams(input, ImmutableList.of());
+
+    MatcherAssert.assertThat(conditions, Matchers.hasSize(4));
+    MatcherAssert.assertThat(conditions.get(0).getServices(),
+        Matchers.containsInAnyOrder("a", "e"));
+    MatcherAssert.assertThat(conditions.get(0).getMustNotServiceCodes(),
+        Matchers.containsInAnyOrder("b", "d"));
+  }
+
+  @Test
+  public void testNullCollection() {
+    ServicesConditionFactory factory = new ServicesConditionFactory();
+    final ImmutableList<ServicesCondition> conditions = factory.fromRequestParams(null, null);
+    MatcherAssert.assertThat(conditions, Matchers.notNullValue());
+    MatcherAssert.assertThat(conditions, Matchers.hasSize(0));
+  }
+}


### PR DESCRIPTION
Working on updating the v2 search to enable multiple serviceCodes and matchAny sets.

Example:

If the API receives a request like the following:

serviceCodes=a,b,c&serviceCodes=x&serviceCodes=y

The search components would consider that as 3 different search conditions

Set 0: [a, b, c]
Set 1: [x]
Set 2: [y]

This is also okay:

serviceCodes=a,b,!c&serviceCodes=x&serviceCodes=z

Set 0: [a, b] - Set !: [c]
Set 1: [x]
Set 2: [y]

If a service code is prefixed with a bang we will filter out locations for that set that contain that service.







